### PR TITLE
Fix bug #501: (Keysystems) removed wrong parameter

### DIFF
--- a/ddclient.in
+++ b/ddclient.in
@@ -539,7 +539,7 @@ my %variables = (
         'wildcard'            => setv(T_BOOL,  0, 1, 0,                    undef),
     },
     'keysystems-common-defaults' => {
-        'server'              => setv(T_FQDNP, 1, 0, 1, 'dynamicdns.key-systems.net', undef),
+        'server'              => setv(T_FQDNP, 1, 0, 'dynamicdns.key-systems.net', undef),
         'login'               => setv(T_LOGIN, 0, 0, 0, 'unused',      undef),
     },
     'dnsexit-common-defaults'       => {


### PR DESCRIPTION
Hi, 
It looks like the bug is in line 542 in ddclient.in. The syntax of how the server URL is being set is different to all the other dynamic DNS services. To be precise there is one additional parameter. Instead of handing over the URL, the server variable receives the second "1" in the code below. 
`      'server'              => setv(T_FQDNP, 1, 0, 1, 'dynamicdns.key-systems.net', undef),`
Removing this extra parameter likely fixes the problem and should produce the correct URL to send off the updating request. 
Hope this works
T
